### PR TITLE
Other fixes to FairBoost

### DIFF
--- a/scripts/FairBoost/main.py
+++ b/scripts/FairBoost/main.py
@@ -10,7 +10,7 @@ from enum import Enum
 from aif360.datasets import BinaryLabelDataset
 from scipy.special import softmax
 from typing import List, Tuple
-import  ipdb
+# import  ipdb
 
 from FairBoost.wrappers import Preprocessing
 

--- a/scripts/notebook.ipynb
+++ b/scripts/notebook.ipynb
@@ -88,7 +88,7 @@
     }
    ],
    "source": [
-    "%pdb on"
+    "%pdb off"
    ]
   },
   {
@@ -184,30 +184,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Transforming data set with:\n",
-      "\t-Reweighing\n",
-      "\t-OptimPreproc\n",
-      "\t-DisparateImpactRemover\n",
-      "Transforming data set with:\n",
-      "\t-Reweighing\n",
-      "\t-OptimPreproc\n",
-      "\t-DisparateImpactRemover\n"
-     ]
-    },
-    {
      "data": {
       "text/plain": [
-       "0.7943083327646215"
+       "0.7952637685115675"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
## Description
While it was not obvious, default and none bootstrapping methods were not correctly implemented. 

- default boostraping do not call `initialize_boostrap` method 
- None boostraping does not do boostrapping

Closes #27 